### PR TITLE
날씨 조회 API 호출수 개선 및 스케줄러 동작 시간 지연 적용

### DIFF
--- a/src/main/java/project/app/apns_server/infra/SchedulerConfig.java
+++ b/src/main/java/project/app/apns_server/infra/SchedulerConfig.java
@@ -21,12 +21,6 @@ import java.util.concurrent.TimeUnit;
 @Configuration
 public class SchedulerConfig implements SchedulingConfigurer {
 
-    @Value("${weather.search.scheduler.period}")
-    private Long period;
-
-    @Value("${weather.search.scheduler.time-unit}")
-    private String timeUnit;
-
     @Override
     public void configureTasks(ScheduledTaskRegistrar taskRegistrar){
         ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
@@ -42,11 +36,5 @@ public class SchedulerConfig implements SchedulingConfigurer {
     public Map<String, ScheduledFuture<?>> scheduledTasks() {
         return new HashMap<>();
     }
-
-    @Bean
-    public Trigger trigger() {
-        return new PeriodicTrigger(period, TimeUnit.valueOf(timeUnit));
-    }
-
 
 }

--- a/src/main/java/project/app/apns_server/modules/controller/MainController.java
+++ b/src/main/java/project/app/apns_server/modules/controller/MainController.java
@@ -25,17 +25,10 @@ public class MainController {
 
     private final SchedulerTaskService schedulerTaskService;
     private final AppInfoRedisService appInfoRedisService;
-    private final WeatherSearchService weatherSearchService;
 
     @PostMapping("/init/app/info")
     public ResponseEntity<Response> saveAppAndWeatherInitInfo(@RequestBody @Valid AppInfoRequestDto appInfoRequest) {
-
-        // 현재 앱의 위치에 맞는 날씨 조회
-        WeatherApiResponseDto weatherInfo = weatherSearchService
-                .requestCurrWeatherByLocation(appInfoRequest.getLatitude(), appInfoRequest.getLongitude());
-
-        // 조회한 날씨와 요청한 앱의 정보 Redis 저장
-        AppInfoVo appInfo = AppInfoVo.of(appInfoRequest, weatherInfo);
+        AppInfoVo appInfo = AppInfoVo.of(appInfoRequest);
         boolean isUpdate = appInfoRedisService.saveInfo(appInfo);
         if(!isUpdate) schedulerTaskService.startScheduler(appInfo.getDeviceToken());
         return new ResponseEntity<>(Response.success(appInfo), HttpStatus.CREATED);

--- a/src/main/java/project/app/apns_server/modules/dto/AppInfoRequestDto.java
+++ b/src/main/java/project/app/apns_server/modules/dto/AppInfoRequestDto.java
@@ -12,7 +12,7 @@ import lombok.ToString;
 
 /**
  * LiveActivity 를 실행한 앱의 토큰과 위치 정보
- * @Param :  Device token, LiveActivity token, 위도(Latitude), 경도(longitude)
+ * @Param :  Device token, LiveActivity token, 위도(Latitude), 경도(longitude), 온도(temperature)
  */
 @ToString
 @Getter
@@ -35,4 +35,7 @@ public class AppInfoRequestDto {
     @JsonProperty("lon")
     @NotNull(message = "경도(lon) 미입력")
     private Double longitude;
+
+    @JsonProperty("temperature")
+    private long temp;
 }

--- a/src/main/java/project/app/apns_server/modules/service/scheduler/DelayedStartTrigger.java
+++ b/src/main/java/project/app/apns_server/modules/service/scheduler/DelayedStartTrigger.java
@@ -1,0 +1,33 @@
+package project.app.apns_server.modules.service.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class DelayedStartTrigger implements Trigger {
+
+    private final TimeUnitConvertService timeUnitConvertService;
+
+    private Boolean isFirstExecution = true;
+
+    @Override
+    public Instant nextExecution(TriggerContext triggerContext) {
+        long delay = timeUnitConvertService.getPeriodToMilliseconds();
+        if (isFirstExecution) {
+            isFirstExecution= false;
+            return Instant.now().plusMillis(delay);
+        } else {
+
+            Instant instant = triggerContext.lastScheduledExecution() == null ?
+                    Instant.now() : triggerContext.lastScheduledExecution();
+
+            assert instant != null;
+            return instant.plusMillis(delay);
+        }
+    }
+}

--- a/src/main/java/project/app/apns_server/modules/service/scheduler/SchedulerTaskService.java
+++ b/src/main/java/project/app/apns_server/modules/service/scheduler/SchedulerTaskService.java
@@ -30,15 +30,10 @@ public class SchedulerTaskService {
     private final Map<String, ScheduledFuture<?>> scheduledTasks;
     private final Trigger trigger;
 
+    private final TimeUnitConvertService timeUnitConvertService;
     private final AppInfoRedisServiceImpl appInfoRedisService;
     private final WeatherSearchService weatherSearchService;
     private final ApplicationEventPublisher eventPublisher;
-
-    @Value("${weather.search.scheduler.period}")
-    private Long period;
-
-    @Value("${weather.search.scheduler.time-unit}")
-    private String timeUnit;
 
     public void startScheduler(final String deviceToken) {
         scheduler.initialize();
@@ -50,14 +45,14 @@ public class SchedulerTaskService {
         return () -> {
             log.info("[checkWeatherCurrApp] ======= 스케줄러 작업을 시작합니다.(time: {}) =========", LocalDateTime.now());
             AppInfoVo appInfo = appInfoRedisService.findAppInfoByDeviceToken(deviceToken);
+            log.info("\n \t [checkWeatherCurrApp] Device 토큰 = {} \n \t [checkWeatherCurrApp] Push 토큰 = {}", appInfo.getDeviceToken(), appInfo.getPushToken());
             WeatherApiResponseDto currWeather = weatherSearchService.requestCurrWeatherByLocation(appInfo.getLatitude(), appInfo.getLongitude());
             long pastTemp = appInfo.getTemp();
             long currTemp = Math.round(currWeather.mainDto().getTemp());
-            log.info("\n \t [checkWeatherCurrApp] Device 토큰 = {} \n \t [checkWeatherCurrApp] Push 토큰 = {}", appInfo.getDeviceToken(), appInfo.getPushToken());
-            log.info("[checkWeatherCurrApp] {}{} 전 온도 = {}°C, 현재 온도 = {}°C ", period, getTimeUnit(), pastTemp, currTemp);
+            log.info("[checkWeatherCurrApp] {}{} 전 온도 = {}°C, 현재 온도 = {}°C ", timeUnitConvertService.getPeriod(), timeUnitConvertService.getTimeUnit(), pastTemp, currTemp);
 
             if (isTemperatureDifference(pastTemp, currTemp)) {
-                log.info("[checkWeatherCurrApp] {}{} 전 온도와 현재 온도 차이가 발생했습니다.", period, getTimeUnit());
+                log.info("[checkWeatherCurrApp] {}{} 전 온도와 현재 온도 차이가 발생했습니다.", timeUnitConvertService.getPeriod(), timeUnitConvertService.getTimeUnit());
                 appInfo.updateCurrTemp(currTemp);
                 appInfoRedisService.saveInfo(appInfo);
                 eventPublisher.publishEvent(PushNotificationEventDto.of(appInfo));
@@ -73,13 +68,6 @@ public class SchedulerTaskService {
         }
     }
 
-    private String getTimeUnit() {
-        return switch (timeUnit) {
-            case "MINUTES" -> "분";
-            case "SECONDS" -> "초";
-            default -> timeUnit;
-        };
-    }
 
     // 과거온도와 현재온도 차이가 있으면 true
     private boolean isTemperatureDifference(long pastTemp, long currTemp) {

--- a/src/main/java/project/app/apns_server/modules/service/scheduler/TimeUnitConvertService.java
+++ b/src/main/java/project/app/apns_server/modules/service/scheduler/TimeUnitConvertService.java
@@ -1,0 +1,38 @@
+package project.app.apns_server.modules.service.scheduler;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TimeUnitConvertService {
+
+    private static final long MILLISECONDS = 1_000;
+
+    @Value("${weather.search.scheduler.period}")
+    private Long period;
+
+    @Value("${weather.search.scheduler.time-unit}")
+    private String timeUnit;
+
+    public String getTimeUnit() {
+        return switch (this.timeUnit) {
+            case "HOURS" -> "시";
+            case "MINUTES" -> "분";
+            case "SECONDS" -> "초";
+            default -> this.timeUnit;
+        };
+    }
+
+    public Long getPeriodToMilliseconds() {
+        return switch (this.timeUnit) {
+            case "HOURS" -> this.period*MILLISECONDS*3600;
+            case "MINUTES" -> this.period*MILLISECONDS*60;
+            case "SECONDS" -> this.period*MILLISECONDS;
+            default -> this.period;
+        };
+    }
+
+    public Long getPeriod() {
+        return this.period;
+    }
+}

--- a/src/main/java/project/app/apns_server/modules/vo/AppInfoVo.java
+++ b/src/main/java/project/app/apns_server/modules/vo/AppInfoVo.java
@@ -43,6 +43,15 @@ public class AppInfoVo {
                 .build();
     }
 
+    public static AppInfoVo of(AppInfoRequestDto appInfo) {
+        return new AppInfoVo(
+                appInfo.getDeviceToken(),
+                appInfo.getPushToken(),
+                appInfo.getLatitude(),
+                appInfo.getLongitude(),
+                appInfo.getTemp());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;


### PR DESCRIPTION
## 수행내용
- Weather Kit(Apple 날씨 조회) API 호출수 개선
     - 사용자 Live activity 활성화 횟수(n) 만큼 불필요하게 외부 API가 호출되고 있음
     - API 호출에 따른 비용이 발생하기 때문에 비용 문제를 해결하기 위해 개선
- 스케줄러 동작 시작 시간 지역 트리거 적용
     - 기존에는 Live activity 활성화에 따른 API가 호출되면 스케줄러가 즉시 동작함
     - 앱은 이미 업데이트 되어있는 상태이기 때문에 불필요함
     - API가 요청되고 탐색 주기(예:30분) 뒤에 스케줄러가 동작하도록 개선
     
## 변경내용
- 앱의 정보 및 날씨 저장 API 수정
     - Request Body 포함 데이터 수정 (온도 추가)